### PR TITLE
fix: Allow all domains on liftedinit.tech

### DIFF
--- a/src/features/network/store.ts
+++ b/src/features/network/store.ts
@@ -4,6 +4,8 @@ import localforage from "localforage"
 import { replacer, reviver } from "shared/helpers"
 import { NetworkId, NetworkParams, NetworksState } from "./types"
 
+const devDomains = ["localhost", "liftedinit.tech"]
+
 const initialState = {
   activeId: 0,
   nextId: 3,
@@ -37,7 +39,7 @@ export const useNetworkStore = create<NetworksState & NetworkActions>(
             ({ filter }) =>
               !filter ||
               hostname.includes(filter) ||
-              hostname.includes("localhost"),
+              devDomains.some(domain => hostname.includes(domain)),
           )
         return networks
       },


### PR DESCRIPTION
## Description

@jgryffindor is trying to get the NGINX stuff to work on `dev001.liftedinit.tech` but since that domain doesn't match either "alberto" or "end-labs", neither ledger is showing up in the dropdown. This PR adds a "whitelist" of dev/stage domains that will allow all ledgers to appear (but they might not work).

Closes https://github.com/liftedinit/operations/issues/6 (but doesn't)