### PR TITLE
fix: multisig tx details

### DIFF
--- a/src/features/accounts/api/get-multisig-txn-info.ts
+++ b/src/features/accounts/api/get-multisig-txn-info.ts
@@ -2,14 +2,77 @@ import { useQuery } from "react-query"
 import { useNetworkContext } from "features/network"
 import { MultisigInfoResponse } from "@liftedinit/many-js"
 
-export function useGetMultisigTxnInfo(token?: ArrayBuffer) {
-  const [n] = useNetworkContext()
+const transactionNotFound = new Error("The transaction cannot be found.")
+type ResponseOrError = MultisigInfoResponse | Error
+type MultisigInfoFromNetworks = {
+  isLegacyOnly: boolean
+  info: MultisigInfoResponse[]
+}
 
-  return useQuery<MultisigInfoResponse, Error>({
+export function useGetMultisigTxnInfo(token?: ArrayBuffer) {
+  const [n, , l] = useNetworkContext()
+  // Create a network list from n and l, excluding undefined values and empty arrays
+  // `n` is the active network
+  // `l` is the legacy network list
+  const networkList = [...(n ? [n] : []), ...(l || [])]
+
+  return useQuery<MultisigInfoFromNetworks, Error>({
     queryKey: ["multisigTxnInfo", token],
     queryFn: async () => {
-      const res = await n?.account.multisigInfo(token)
-      return res
+      if (networkList.length === 0) {
+        throw new Error("Network context is empty")
+      }
+
+      // Try to find the transaction on the active network
+      const resActive: ResponseOrError = await n?.account
+        .multisigInfo(token)
+        .catch((err: Error) => {
+          if (err.message === transactionNotFound.message) {
+            return transactionNotFound
+          }
+          return err
+        })
+
+      // Try to find the transaction on the legacy networks
+      let resLegacy = await Promise.all(
+        (l || []).map(item =>
+          item.account.multisigInfo(token).catch((err: Error) => {
+            if (err.message === transactionNotFound.message) {
+              return transactionNotFound
+            }
+            return err
+          }),
+        ),
+      )
+
+      // Remove the transactionNotFound errors from the result
+      resLegacy = resLegacy.filter(
+        item =>
+          !(
+            item instanceof Error &&
+            item.message === transactionNotFound.message
+          ),
+      )
+
+      // Initialize the result with the active network result if it is not an error, else initialize it with an empty array
+      let res: MultisigInfoResponse[] = !(resActive instanceof Error)
+        ? [resActive]
+        : []
+
+      // Add the legacy network results to the result
+      if (resLegacy.length > 0) {
+        res = [...res, ...resLegacy]
+      }
+
+      // Check if the result comes from legacy networks only
+      let legacyOnly = res.length > 0 && resActive instanceof Error
+
+      // If the result is empty, then the transaction really is not found on any network
+      if (res.length === 0) {
+        throw transactionNotFound
+      }
+
+      return { isLegacyOnly: legacyOnly, info: res }
     },
     enabled: !!token,
   })

--- a/src/features/network/network-provider.tsx
+++ b/src/features/network/network-provider.tsx
@@ -11,13 +11,15 @@ import {
 import { useNetworkStore } from "./store"
 import { useAccountsStore } from "features/accounts"
 
-const NetworkContext = React.createContext<[Network?, Network?]>([
-  undefined,
-  undefined,
+const NetworkContext = React.createContext<[Network?, Network?, Network[]?]>([
+  undefined, // Query network
+  undefined, // Legacy networks
+  undefined, // Command network
 ])
 
 export function NetworkProvider({ children }: React.PropsWithChildren<{}>) {
   const activeNetwork = useNetworkStore(state => state.getActiveNetwork())
+  const legacyNetworks = useNetworkStore(state => state.getLegacyNetworks())
   const activeAccount = useAccountsStore(state =>
     state.byId.get(state.activeId),
   )!
@@ -30,8 +32,20 @@ export function NetworkProvider({ children }: React.PropsWithChildren<{}>) {
     queryNetwork.apply([Ledger, IdStore, Account, Events, Base])
     const cmdNetwork = new Network(url, identity)
     cmdNetwork.apply([Ledger, IdStore, Account])
-    return [queryNetwork, cmdNetwork] as [Network, Network]
-  }, [activeNetwork, activeAccount])
+    const eventNetworks =
+      activeNetwork?.name.toLowerCase() === "manifest ledger" // FIXME: Filtering by the network name is dumb. Improve me.
+        ? legacyNetworks?.map(params => {
+            const network = new Network(params.url, anonIdentity)
+            network.apply([Account, Events])
+            return network
+          })
+        : []
+    return [queryNetwork, cmdNetwork, eventNetworks] as [
+      Network,
+      Network,
+      Network[],
+    ]
+  }, [activeNetwork, legacyNetworks, activeAccount])
 
   return (
     <NetworkContext.Provider value={network}>


### PR DESCRIPTION
Retrieve multisig transaction details from current and legacy networks.

This PR support `N` legacy networks.

Any multisig transaction in a pending state on a legacy network will need to be re-created on the new network. Those pending multisig will remain pending indefinitely, as we do not want to modify the legacy storage.

Future work: 
- Add a label identifying which network a transaction belongs to.
- Add more (e2e) tests

I also did some small refactoring.

@stanleyjones is there a reason why we're not using more native many-js types in Alberto, e.g., we're using `string` instead of `MultisigTransactionState`. I saw this behavior often in Gwen/Alberto and was wondering what the reason was.