### PR TITLE
fix: transaction listing from multiple backends

### DIFF
--- a/src/features/transactions/queries.ts
+++ b/src/features/transactions/queries.ts
@@ -1,22 +1,15 @@
-import React from "react"
-import { useNetworkContext, useNetworkStore } from "features/network"
+import { useNetworkContext } from "features/network"
 import {
-  AnonymousIdentity,
   BoundType,
   Event,
-  Events,
-  EventsListResponse,
   ListFilterArgs,
   ListOrderType,
-  Network,
 } from "@liftedinit/many-js"
-import {
-  useMutation,
-  useQueries,
-  useQueryClient,
-  UseQueryResult,
-} from "react-query"
+import { useMutation, useQueryClient } from "react-query"
 import { arrayBufferToBase64 } from "@liftedinit/ui"
+import React, { useEffect } from "react"
+
+const PAGE_SIZE = 11
 
 export function useCreateSendTxn() {
   const [, network] = useNetworkContext()
@@ -44,94 +37,124 @@ export function useCreateSendTxn() {
   )
 }
 
+interface TransactionsListArgs {
+  address?: string
+  filter?: Omit<ListFilterArgs, "txnIdRange"> & {
+    txnIdRange?: ({ boundType: BoundType; value: ArrayBuffer } | undefined)[]
+  }
+  count?: number
+}
+
+// TODO: Aggregating data from multiple backends should be handled (and cached) by another system.
+//       We should only query this other system from the frontend.
 export function useTransactionsList({
   address,
   filter = {},
-  count: reqCount = 11,
-}: {
-  address?: string
-  filter?: Omit<ListFilterArgs, "txnIdRange"> & {
-    txnIdRange?: { boundType: BoundType; value: ArrayBuffer }[]
-  }
-  count?: number
-}) {
-  const [network] = useNetworkContext()
+  count: reqCount = PAGE_SIZE,
+}: TransactionsListArgs) {
+  const [data, setData] = React.useState<any[]>([])
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState(Error)
   const [txnIds, setTxnIds] = React.useState<ArrayBuffer[]>([])
+  const [activeNetwork, , legacyNetworks] = useNetworkContext()
 
-  const filters = {
-    accounts: address,
-    ...(txnIds.length > 0
-      ? {
-          txnIdRange: [
-            undefined,
-            { boundType: BoundType.inclusive, value: txnIds[0] },
-          ],
+  const filterRef = React.useRef(filter)
+
+  useEffect(() => {
+    const fetchQueries = async () => {
+      try {
+        setLoading(true)
+        const backends = [
+          ...(activeNetwork ? [activeNetwork] : []),
+          ...(legacyNetworks || []),
+        ]
+        let resultData: Event[] = []
+
+        // Filter by account address and any filter given by the user
+        const filters = {
+          accounts: address,
+          ...filterRef.current,
         }
-      : {}),
-    ...filter,
-  }
-  const q = [
-    {
-      queryKey: ["events", "list", address, filters, network?.url],
-      queryFn: async () =>
-        await network?.events?.list({
-          filters,
-          count: reqCount,
-          order: ListOrderType.descending,
-        }),
-      enabled: !!network?.url,
-      keepPreviousData: true,
-    },
-  ]
 
-  const activeNetwork = useNetworkStore(state => state.getActiveNetwork())
-  const legacyNetworksParams = useNetworkStore(state =>
-    state.getLegacyNetworks(),
-  )
-  const legacyNetworks = legacyNetworksParams.map(legacyNetworkParam => {
-    const url = legacyNetworkParam?.url || ""
-    const network = new Network(url, new AnonymousIdentity())
-    network.apply([Events])
-    return network
-  })
-  const legacy_q = legacyNetworks.map(legacyNetwork => ({
-    queryKey: ["events", "list", address, filters, legacyNetwork?.url],
-    queryFn: async () =>
-      await legacyNetwork?.events?.list({
-        filters,
-        count: reqCount,
-        order: ListOrderType.descending,
-      }),
-    enabled:
-      activeNetwork?.name?.toLowerCase() === "manifest ledger" &&
-      !!legacyNetwork?.url,
-    keepPreviousData: true,
-  }))
+        let checkTx = false // Flag to check if txnIds[0] exists in the current backend
 
-  const allData = useQueries({
-    queries: [...q, ...legacy_q],
-  }) as UseQueryResult<EventsListResponse, Error>[]
+        // txnIds[0] is the last (hidden) transaction from the previous page / the first transaction of the next page
+        // Create a filter that will look that this transaction exists in the current endpoint
+        // This is a workaround for https://github.com/liftedinit/many-rs/issues/404
+        if (txnIds.length > 0) {
+          filters.txnIdRange = [
+            { boundType: BoundType.inclusive, value: txnIds[0] },
+            { boundType: BoundType.inclusive, value: txnIds[0] },
+          ]
+          checkTx = true
+        }
 
-  const txnsWithId = allData.flatMap(
-    queryResult =>
-      queryResult.data?.events.map((t: Event) => ({
-        ...t,
-        time: t.time * 1000,
-        _id: arrayBufferToBase64(t.id),
-      })) || [],
-  )
+        let counter = reqCount
+        for (const backend of backends) {
+          // Get the data from the current endpoint
+          let response = await backend.events?.list({
+            count: counter,
+            order: ListOrderType.descending,
+            filters,
+          })
+          const response_length = response?.events.length
 
-  const respCount = txnsWithId.length
-  const hasNextPage = respCount >= reqCount
-  const visibleTxnsWithId = hasNextPage
-    ? txnsWithId.slice(0, reqCount - 1)
-    : txnsWithId
+          // The current backend has no data; try the next one
+          if (response_length === 0 && checkTx) {
+            continue
+          } else if (response_length === 1 && checkTx) {
+            // txnIds[0] exists in the current backend; query the backend again for the remaining transactions
+            checkTx = false
+            filters.txnIdRange = [
+              undefined,
+              { boundType: BoundType.inclusive, value: txnIds[0] },
+            ]
+            response = await backend.events?.list({
+              count: counter,
+              order: ListOrderType.descending,
+              filters,
+            })
+          }
+
+          resultData = resultData.concat(
+            response?.events.map((t: Event) => ({
+              ...t,
+              time: t.time * 1000,
+              _id: arrayBufferToBase64(t.id),
+            })) || [],
+          )
+
+          // At this point the current backend has some data. Do we have enough?
+          if (
+            response?.events.length === reqCount ||
+            resultData.length === reqCount
+          ) {
+            // We have enough data for the current page, break
+            break
+          }
+
+          // At this point we have some data but not enough for the current page
+          // Try to get the remaining data from the next backend
+          counter = reqCount - resultData.length
+          delete filters.txnIdRange // Remove the filter, if any
+        }
+        setData(resultData)
+        setLoading(false)
+      } catch (err) {
+        setError(err as Error)
+        setLoading(false)
+      }
+    }
+    fetchQueries()
+  }, [address, reqCount, activeNetwork, legacyNetworks, txnIds])
+
+  const hasNextPage = data.length === PAGE_SIZE
+  const visibleTxnsWithId = hasNextPage ? data.slice(0, PAGE_SIZE - 1) : data
 
   return {
-    isPreviousData: allData.some(result => result.isPreviousData),
-    error: allData.find(result => result.error)?.error?.message,
-    isError: allData.some(result => result.isError),
-    isLoading: allData.some(result => result.isFetching),
+    error: error?.message,
+    isError: error,
+    isLoading: loading,
     hasNextPage,
     currPageCount: txnIds.length,
     prevBtnProps: {
@@ -143,12 +166,12 @@ export function useTransactionsList({
     nextBtnProps: {
       disabled: !hasNextPage,
       onClick: () => {
-        const lastTxn = txnsWithId[reqCount - 1]
+        const lastTxn = data[PAGE_SIZE - 1]
         setTxnIds(s => [lastTxn.id, ...s])
       },
     },
     data: {
-      count: txnsWithId.length,
+      count: data.length,
       transactions: visibleTxnsWithId ?? [],
     },
   }


### PR DESCRIPTION
Refactor `useTransactionsList` and fix history pagination when using multiple backends.

This is not an idiomatic way of doing this kind of task but this is what we have for the moment...

Relates https://github.com/liftedinit/many-rs/issues/404