### PR TITLE
fix: group destination address

### DIFF
--- a/src/features/token-migration/destination-address.tsx
+++ b/src/features/token-migration/destination-address.tsx
@@ -1,1 +1,2 @@
-export const DestinationAddressRegex = /^manifest[a-zA-Z0-9]{39}$/
+export const DestinationAddressRegex =
+  /^manifest([a-zA-Z0-9]{39}|[a-zA-Z0-9]{59})$/


### PR DESCRIPTION
This pull request updates the regular expression used for validating destination addresses in the `DestinationAddressRegex` constant to support an additional address format.

Validation update:

* [`src/features/token-migration/destination-address.tsx`](diffhunk://#diff-7d6becde0a2531957809a39b044b5cd121d52f48ee5d27fc47dc8315a7633a71L1-R2): Modified the `DestinationAddressRegex` to allow addresses with 59 alphanumeric characters in addition to the existing 39-character format.