### PR TITLE
fix: 1:10 split

### DIFF
--- a/src/features/token-migration/components/migration-form/amount-asset-step.tsx
+++ b/src/features/token-migration/components/migration-form/amount-asset-step.tsx
@@ -122,13 +122,14 @@ export const AmountAssetStep = ({
             <UnorderedList mb={2} mt={2} pl={4}>
               <ListItem>
                 {" "}
-                For every 1 MFX token you migrate, you will receive 10 MFX
-                tokens on the MANIFEST chain.{" "}
+                For every 1 MFX token you migrate from the MANY chain, you will
+                receive 10 MFX tokens on the MANIFEST chain.{" "}
               </ListItem>
               <ListItem>
                 {" "}
                 Even smaller amounts are adjusted accordingly: migrating
-                0.0000001 MFX token will result in receiving 1 umfx token.{" "}
+                0.0000001 MFX token from the MANY chain will result in receiving
+                0.000001 MFX token on the MANIFEST chain.{" "}
               </ListItem>
               <ListItem>
                 {" "}

--- a/src/features/token-migration/components/migration-form/amount-asset-step.tsx
+++ b/src/features/token-migration/components/migration-form/amount-asset-step.tsx
@@ -77,21 +77,21 @@ export const AmountAssetStep = ({
       })
       .test(
         "is-amount-in-range",
-        "Amount must be greater than 1e-8 and less than or equal to your balance",
+        "Amount must be greater than 1e-7 and less than or equal to your balance",
         function (value) {
           if (value === undefined) return false
           try {
             const bigValue = Big(value)
-            return bigValue.gte(1e-8) && bigValue.lte(currentMaxAmount)
+            return bigValue.gte(1e-7) && bigValue.lte(currentMaxAmount)
           } catch (error) {
             return false
           }
         },
       )
-      .test("decimal-places", "Cannot exceed 8 decimal places", value => {
+      .test("decimal-places", "Cannot exceed 7 decimal places", value => {
         if (!value) return false
         const decimalPlaces = value.split(".")[1]
-        return !decimalPlaces || decimalPlaces.length <= 8
+        return !decimalPlaces || decimalPlaces.length <= 7
       })
       .required("Required"),
     assetSymbol: Yup.string().required("Required"),
@@ -116,23 +116,23 @@ export const AmountAssetStep = ({
             </Text>
             <Text mb={4}>
               As part of our migration to the MANIFEST chain, the amount of any
-              asset you transfer will be adjusted according to a 1:100 token
+              asset you transfer will be adjusted according to a 1:10 token
               migration ratio. This means:
             </Text>
             <UnorderedList mb={2} mt={2} pl={4}>
               <ListItem>
                 {" "}
-                For every 1 MFX token you migrate, you will receive 100 MFX
+                For every 1 MFX token you migrate, you will receive 10 MFX
                 tokens on the MANIFEST chain.{" "}
               </ListItem>
               <ListItem>
                 {" "}
                 Even smaller amounts are adjusted accordingly: migrating
-                0.00000001 MFX token will result in receiving 1 umfx token.{" "}
+                0.0000001 MFX token will result in receiving 1 umfx token.{" "}
               </ListItem>
               <ListItem>
                 {" "}
-                Amounts less than 0.00000001 MFX token will not be migrated.{" "}
+                Amounts less than 0.0000001 MFX token will not be migrated.{" "}
               </ListItem>
             </UnorderedList>
             <Text mb={4}>

--- a/src/features/token-migration/components/migration-form/terms-and-conditions.tsx
+++ b/src/features/token-migration/components/migration-form/terms-and-conditions.tsx
@@ -224,7 +224,7 @@ a.  Accepted Tokens. Only Alpha Tokens are accepted in exchange for
     type of token or currency.
 
 b.  Migration Period. Alpha Tokens may be submitted in exchange for
-    Mainnet Tokens, on a 1-for-100 ratio, beginning on March 31st,
+    Mainnet Tokens, on a 1-for-10 ratio, beginning on March 31st,
     2025, at 12:00 pm EST and will continue indefinitely until the
     Alpha Network is no longer supported by The Lifted Initiative,
     Inc. (issuer of the Alpha Tokens) (the "Migration Period").
@@ -264,7 +264,7 @@ e.  Transferability of Mainnet Tokens. Notwithstanding any other
     sale and/or transfer of Mainnet Tokens.
 
 f.  Excluded Contributions. The Token Migration involves only the
-    exchange of Alpha Tokens for Mainnet Tokens on a 1-for-100
+    exchange of Alpha Tokens for Mainnet Tokens on a 1-for-10
     basis. Any other type of consideration, including any type of
     fiat or cryptocurrency will not be accepted.
 


### PR DESCRIPTION
This pull request includes updates to the token migration logic and associated user-facing text to reflect a change in the token migration ratio and validation rules. The most important changes include modifying the migration ratio from 1:100 to 1:10, adjusting validation thresholds for token amounts, and updating the terms and conditions to align with the new ratio.

### Updates to token migration ratio:
* [`src/features/token-migration/components/migration-form/amount-asset-step.tsx`](diffhunk://#diff-d024fc7bb3b25b972a5dc5555309fae6f0b7f96de07a564e782359b2177f3317L119-R135): Updated the migration ratio in the user-facing text from 1:100 to 1:10. This includes changes to the description of how tokens will be adjusted during migration and examples of token conversions.
* [`src/features/token-migration/components/migration-form/terms-and-conditions.tsx`](diffhunk://#diff-13d840cd1fefa56697f36be3b1f5f7583f233a6d587db09c3d66613c7db5b1a0L227-R227): Updated the terms and conditions to reflect the new 1:10 migration ratio, replacing the previous 1:100 ratio in multiple sections. [[1]](diffhunk://#diff-13d840cd1fefa56697f36be3b1f5f7583f233a6d587db09c3d66613c7db5b1a0L227-R227) [[2]](diffhunk://#diff-13d840cd1fefa56697f36be3b1f5f7583f233a6d587db09c3d66613c7db5b1a0L267-R267)

### Validation rule adjustments:
* [`src/features/token-migration/components/migration-form/amount-asset-step.tsx`](diffhunk://#diff-d024fc7bb3b25b972a5dc5555309fae6f0b7f96de07a564e782359b2177f3317L80-R94): Adjusted the minimum token amount validation threshold from `1e-8` to `1e-7` and reduced the maximum allowed decimal places from 8 to 7. These changes ensure consistency with the new migration ratio and token handling rules.