### PR TITLE
fix: remove migration banner

### DIFF
--- a/src/views/layout/app-nav.tsx
+++ b/src/views/layout/app-nav.tsx
@@ -1,13 +1,13 @@
 import { Flex } from "@liftedinit/ui"
 import { NetworkMenu } from "features/network"
 import { AccountsMenu } from "features/accounts"
-import { MigrationBanner } from "../../features/token-migration"
+// import { MigrationBanner } from "../../features/token-migration"
 
 export function AppNav() {
   return (
     <Flex justify="space-between" alignItems="center" p={2} overflow="hidden">
       <AccountsMenu />
-      <MigrationBanner />
+      {/*<MigrationBanner />*/}
       <NetworkMenu />
     </Flex>
   )


### PR DESCRIPTION
This pull request includes a small change to the `src/views/layout/app-nav.tsx` file. The change comments out the `MigrationBanner` component, effectively removing it from the application navigation layout.